### PR TITLE
Fix docblock annotation

### DIFF
--- a/src/AwsS3V3PlusAdapter.php
+++ b/src/AwsS3V3PlusAdapter.php
@@ -75,7 +75,7 @@ class AwsS3V3PlusAdapter extends FilesystemAdapter
      * @throws LogicException
      * @throws InvalidArgumentException
      */
-    public function temporaryUrl($path, $expiration, array $options = [], string $versionId = null)
+    public function temporaryUrl($path, $expiration, array $options = [], ?string $versionId = null)
     {
         $version = $versionId ? ['VersionId' => $versionId] : [];
 
@@ -324,7 +324,7 @@ class AwsS3V3PlusAdapter extends FilesystemAdapter
     /**
      * @throws Throwable|UnableToRestoreFile
      */
-    public function restore(string $path, string $versionId = null): bool
+    public function restore(string $path, ?string $versionId = null): bool
     {
         $success = true;
 

--- a/src/AwsS3V3PlusAdapter.php
+++ b/src/AwsS3V3PlusAdapter.php
@@ -209,7 +209,7 @@ class AwsS3V3PlusAdapter extends FilesystemAdapter
     }
 
     /**
-     * @return Collection<int, array{hash: string, key: string, version: string, type: string, latest: bool, updatedAt: CarbonImmutable, size: int}>
+     * @return Collection<int, array{id: string, hash: string, key: string, type: string, latest: bool, updatedAt: CarbonImmutable, size: int}>
      *
      * @throws UnableToListVersions
      */


### PR DESCRIPTION
This PR fixes a reference to a `version` key, in the docblock of  `versions()` method, which isn't present in the internal collection array structure but an `id` instead.